### PR TITLE
feat: add settings dialog for default output directory management

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -7,13 +7,28 @@ import Column from 'primevue/column';
 import { formatSize, formatTime, UnpackStatusType, useAppToast } from "./entries/util";
 import Toast from 'primevue/toast';
 import UnpackDialog from "./components/UnpackDialog.vue";
+import SettingsDialog from "./components/SettingsDialog.vue";
 import {wechat} from "../wailsjs/go/models";
 import WxapkgItem = wechat.WxapkgItem;
 import UnpackOptions = wechat.UnpackOptions;
 import * as AppService from '../wailsjs/go/main/AppService';
 
+interface OutputDirSelectionPayload {
+  outputDir: string;
+  setAsDefault: boolean;
+  useInSession: boolean;
+}
+
+interface StoredOutputDirectoryPreference {
+  defaultOutputDir: string;
+  lastOutputDir: string;
+}
+
+const OUTPUT_DIRECTORY_PREF_STORAGE_KEY = 'wxapkg:output-directory:preference:v1';
+
 const scanDialogVisible = ref(false)
 const unpackDialogVisible = ref(false)
+const settingsDialogVisible = ref(false)
 const search = ref<string>('')
 const wxapkgItems = ref<WxapkgItem[]>([]);
 const toast = useAppToast()
@@ -21,6 +36,9 @@ const version = ref<string>('v0.0.0')
 const github = ref<string>('https://github.com')
 const selectedWxapkgItem = ref<WxapkgItem | null>(null);
 const tableKey = ref<string>('main-table')
+const defaultOutputDir = ref('')
+const lastOutputDir = ref('')
+const sessionOutputDir = ref('')
 
 const filteredItems = computed(() => {
   if (!search.value.trim()) return wxapkgItems.value
@@ -64,6 +82,56 @@ function confirmUnpack(options: UnpackOptions) {
   if (selectedWxapkgItem.value) {
     AppService.UnpackWxapkgItem(selectedWxapkgItem.value, options)
   }
+}
+
+function loadOutputDirectoryPreference() {
+  try {
+    const raw = localStorage.getItem(OUTPUT_DIRECTORY_PREF_STORAGE_KEY)
+    if (!raw) return
+    const parsed = JSON.parse(raw) as Partial<StoredOutputDirectoryPreference>
+    defaultOutputDir.value = (parsed.defaultOutputDir ?? '').trim()
+    lastOutputDir.value = (parsed.lastOutputDir ?? '').trim()
+  } catch {
+    defaultOutputDir.value = ''
+    lastOutputDir.value = ''
+  }
+}
+
+function persistOutputDirectoryPreference() {
+  const data: StoredOutputDirectoryPreference = {
+    defaultOutputDir: defaultOutputDir.value.trim(),
+    lastOutputDir: lastOutputDir.value.trim(),
+  }
+  localStorage.setItem(OUTPUT_DIRECTORY_PREF_STORAGE_KEY, JSON.stringify(data))
+}
+
+function saveDefaultOutputDir(path: string) {
+  defaultOutputDir.value = path.trim()
+  if (sessionOutputDir.value && sessionOutputDir.value === defaultOutputDir.value) {
+    sessionOutputDir.value = ''
+  }
+  persistOutputDirectoryPreference()
+}
+
+function handleOutputDirSelected(payload: OutputDirSelectionPayload) {
+  const dir = payload.outputDir.trim()
+  if (!dir) {
+    return
+  }
+
+  lastOutputDir.value = dir
+
+  if (payload.setAsDefault) {
+    defaultOutputDir.value = dir
+  }
+
+  if (payload.useInSession) {
+    sessionOutputDir.value = dir
+  } else if (sessionOutputDir.value === dir) {
+    sessionOutputDir.value = ''
+  }
+
+  persistOutputDirectoryPreference()
 }
 
 function openUnpackResultDirectory(path: string) {
@@ -132,6 +200,7 @@ function processProgress(uuid: string) {
 }
 
 onMounted(() => {
+  loadOutputDirectoryPreference()
   window.runtime.EventsOn(EventUnpackProgress, (uuid: string) => {
     processProgress(uuid)
   })
@@ -158,6 +227,10 @@ onBeforeUnmount(() => {
         />
       </div>
       <div class="search-actions">
+        <button class="btn-text" style="margin-right: 6px" @click="settingsDialogVisible = true">
+          <i class="pi pi-cog" style="font-size:13px"></i>
+          设置
+        </button>
         <button
           v-if="wxapkgItems.length > 0"
           class="btn-text"
@@ -275,9 +348,18 @@ onBeforeUnmount(() => {
     <UnpackDialog
       v-model:visible="unpackDialogVisible"
       v-model:item="selectedWxapkgItem"
+      :default-output-dir="defaultOutputDir"
+      :last-output-dir="lastOutputDir"
+      :session-output-dir="sessionOutputDir"
       @after-hide="handleDialogHide"
       @confirm="confirmUnpack"
+      @output-dir-selected="handleOutputDirSelected"
       @open-directory="openUnpackResultDirectory"
+    />
+    <SettingsDialog
+      v-model:visible="settingsDialogVisible"
+      :default-output-dir="defaultOutputDir"
+      @save="saveDefaultOutputDir"
     />
     <Toast position="bottom-right" />
   </div>
@@ -430,18 +512,18 @@ onBeforeUnmount(() => {
   display: flex;
   align-items: center;
   gap: 6px;
-  //background: var(--color-light-gray);
+  /* background: var(--color-light-gray); */
   border-radius: 980px;
   padding: 5px 10px;
   flex-shrink: 0;
   cursor: pointer;
   text-decoration: none;
-  //color: rgba(0, 0, 0, 0.5);
+  /* color: rgba(0, 0, 0, 0.5); */
   transition: background 0.15s, color 0.15s;
 }
 .footer-right:hover {
   background: rgba(0, 0, 0, 0.1);
-  //color: var(--color-apple-blue);
+  /* color: var(--color-apple-blue); */
 }
 
 .footer-disclaimer {

--- a/frontend/src/components/SettingsDialog.vue
+++ b/frontend/src/components/SettingsDialog.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import Dialog from 'primevue/dialog'
+import * as AppService from '../../wailsjs/go/main/AppService'
+
+const props = defineProps<{
+  defaultOutputDir: string;
+}>()
+
+const emit = defineEmits<{
+  save: [path: string];
+}>()
+
+const visible = defineModel<boolean>('visible', { default: false })
+const draftOutputDir = ref('')
+
+watch(visible, (newVal) => {
+  if (newVal) {
+    draftOutputDir.value = props.defaultOutputDir ?? ''
+  }
+})
+
+function selectDirectory() {
+  AppService.OpenDirectoryDialog('选择默认输出目录', draftOutputDir.value)
+    .then((path) => {
+      if (path) {
+        draftOutputDir.value = path
+      }
+    })
+}
+
+function clearDirectory() {
+  draftOutputDir.value = ''
+}
+
+function saveSettings() {
+  emit('save', draftOutputDir.value.trim())
+  visible.value = false
+}
+</script>
+
+<template>
+  <Dialog
+    v-model:visible="visible"
+    modal
+    header="设置"
+    :style="{ width: '520px' }"
+    :autofocus="false"
+  >
+    <div class="form-section">
+      <div class="section-label">默认输出目录</div>
+      <div class="form-input-wrapper">
+        <input
+          v-model="draftOutputDir"
+          class="form-input"
+          type="text"
+          placeholder="可手动输入，或点击右侧图标选择目录"
+          style="width:100%; padding-right:40px"
+        />
+        <i
+          class="pi pi-folder form-input-icon-right"
+          style="pointer-events:auto; cursor:pointer"
+          @click="selectDirectory"
+        ></i>
+      </div>
+      <p class="form-hint">
+        未设置时，解包弹窗会优先回填上一次输出目录。
+      </p>
+    </div>
+
+    <div class="dialog-footer" style="padding: 16px 0 0; border: none; justify-content:flex-end; gap:8px">
+      <button class="btn-secondary" @click="clearDirectory">清空默认目录</button>
+      <button class="btn-primary" @click="saveSettings">保存</button>
+    </div>
+  </Dialog>
+</template>
+
+<style scoped>
+.form-section {
+  margin-bottom: 4px;
+}
+
+.form-hint {
+  font-size: 12px;
+  color: var(--color-text-tertiary);
+  margin-top: 8px;
+}
+</style>

--- a/frontend/src/components/UnpackDialog.vue
+++ b/frontend/src/components/UnpackDialog.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import Dialog from 'primevue/dialog';
-import { reactive, ref, watch } from "vue";
+import { computed, reactive, ref, watch } from "vue";
 import * as AppService from '../../wailsjs/go/main/AppService';
 import { UnpackStatusType } from "../entries/util";
 import {wechat} from "../../wailsjs/go/models";
@@ -9,10 +9,27 @@ import WxapkgItem = wechat.WxapkgItem;
 
 type DialogStage = 'config' | 'progress' | 'complete' | 'error';
 
+interface OutputDirSelection {
+  outputDir: string;
+  setAsDefault: boolean;
+  useInSession: boolean;
+}
+
+const props = withDefaults(defineProps<{
+  defaultOutputDir?: string;
+  lastOutputDir?: string;
+  sessionOutputDir?: string;
+}>(), {
+  defaultOutputDir: '',
+  lastOutputDir: '',
+  sessionOutputDir: '',
+});
+
 const emit = defineEmits<{
   confirm: [options: UnpackOptions];
   afterHide: [];
   openDirectory: [path: string];
+  outputDirSelected: [payload: OutputDirSelection];
 }>();
 
 const visible = defineModel<boolean>('visible', { default: false });
@@ -30,6 +47,32 @@ const decryptKey = ref('');
 const currentStage = ref<DialogStage>('config');
 const currentProgress = ref<WxapkgItem | null>(null);
 const actualOutputDir = ref('');
+const setAsDefaultOutputDir = ref(false);
+const useOutputDirInSession = ref(false);
+
+const normalizedDefaultOutputDir = computed(() => normalizeDir(props.defaultOutputDir));
+const shouldShowOutputDirOptions = computed(() => {
+  if (!options.OutputDir) {
+    return false;
+  }
+  return normalizeDir(options.OutputDir) !== normalizedDefaultOutputDir.value;
+});
+
+function isWindowsPlatform(): boolean {
+  return typeof navigator !== 'undefined' && /windows/i.test(navigator.userAgent);
+}
+
+function normalizeDir(path: string): string {
+  const normalizedPath = path.trim().replace(/[\\/]+/g, '/').replace(/\/+$/, '');
+  return isWindowsPlatform() ? normalizedPath.toLowerCase() : normalizedPath;
+}
+
+function getInitialOutputDir(): string {
+  return props.sessionOutputDir.trim()
+    || props.defaultOutputDir.trim()
+    || props.lastOutputDir.trim()
+    || '';
+}
 
 watch(() => [options.OutputDir, item.value?.Location], async () => {
   if (options.OutputDir && item.value) {
@@ -43,8 +86,10 @@ watch(visible, (newVal) => {
   if (newVal && item.value) {
     currentStage.value = 'config';
     currentProgress.value = item.value;
-    options.OutputDir = '';
+    options.OutputDir = getInitialOutputDir();
     options.EnableDecrypt = true;
+    setAsDefaultOutputDir.value = false;
+    useOutputDirInSession.value = false;
 
     if (item.value.WxId && item.value.WxId.startsWith('wx')) {
       decryptKey.value = item.value.WxId;
@@ -61,6 +106,13 @@ watch(visible, (newVal) => {
     } else if (item.value.UnpackStatus === UnpackStatusType.Error) {
       currentStage.value = 'error';
     }
+  }
+});
+
+watch(() => options.OutputDir, () => {
+  if (!shouldShowOutputDirOptions.value) {
+    setAsDefaultOutputDir.value = false;
+    useOutputDirInSession.value = false;
   }
 });
 
@@ -81,12 +133,30 @@ function selectFolder() {
   });
 }
 
-function startUnpack() {
-  if (item.value && decryptKey.value) {
+async function startUnpack() {
+  if (!item.value) {
+    return;
+  }
+
+  if (decryptKey.value) {
     item.value.EncryptKey = decryptKey.value;
   }
-  options.SavePath = actualOutputDir.value;
-  emit('confirm', options);
+
+  const outputDir = options.OutputDir.trim();
+  let savePath = actualOutputDir.value;
+  if (!savePath) {
+    savePath = await AppService.ComputeSavePath(outputDir, item.value.Location);
+  }
+
+  emit('outputDirSelected', {
+    outputDir,
+    setAsDefault: shouldShowOutputDirOptions.value && setAsDefaultOutputDir.value,
+    useInSession: shouldShowOutputDirOptions.value && useOutputDirInSession.value,
+  });
+
+  options.OutputDir = outputDir;
+  options.SavePath = savePath;
+  emit('confirm', { ...options });
   currentStage.value = 'progress';
 }
 
@@ -165,10 +235,8 @@ function minimizeDialog() {
           id="outputDir"
           class="form-input"
           type="text"
-          placeholder="点击右侧图标选择输出目录"
+          placeholder="可手动输入，或点击右侧图标选择输出目录"
           style="width:100%; padding-right:40px"
-          readonly
-          @click="selectFolder"
         />
         <i
           class="pi pi-folder form-input-icon-right"
@@ -181,11 +249,24 @@ function minimizeDialog() {
       </p>
     </div>
 
+    <div class="form-section" v-if="shouldShowOutputDirOptions">
+      <div class="check-group-column">
+        <label class="checkbox-row">
+          <input type="checkbox" v-model="setAsDefaultOutputDir" />
+          <span class="checkbox-row-label">将当前目录作为默认目录</span>
+        </label>
+        <label class="checkbox-row">
+          <input type="checkbox" v-model="useOutputDirInSession" />
+          <span class="checkbox-row-label">下次也使用该目录输出（本次会话有效）</span>
+        </label>
+      </div>
+    </div>
+
     <div class="dialog-footer" style="padding: 16px 0 0; border: none; justify-content:flex-end; gap:8px">
       <button class="btn-secondary" @click="closeDialog">取消</button>
       <button
         class="btn-primary"
-        :disabled="!options.OutputDir || (options.EnableDecrypt && !decryptKey)"
+        :disabled="!options.OutputDir.trim() || (options.EnableDecrypt && !decryptKey)"
         @click="startUnpack"
       >
         开始解包
@@ -302,6 +383,12 @@ function minimizeDialog() {
   display: flex;
   gap: 20px;
   flex-wrap: wrap;
+}
+
+.check-group-column {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .form-hint {

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 //go:embed all:frontend/dist
 var assets embed.FS
 
-var version = "v2.0.0"
+var version = "v2.0.1"
 var github = "https://github.com/wux1an/wxapkg"
 
 func main() {

--- a/wails.json
+++ b/wails.json
@@ -8,7 +8,7 @@
   "frontend:dev:serverUrl": "auto",
   "info": {
     "productName": "微信小程序解包工具",
-    "productVersion": "2.0.0",
+    "productVersion": "2.0.1",
     "companyName": "wux1an",
     "copyright": "© 2026 wux1an. All rights reserved.",
     "comments": "仅供学习研究使用，请勿用于任何侵权或非法用途"


### PR DESCRIPTION
部分小程序会带来数个独立的wxapkg，需要每个都解包确定目标在哪，记住路径便于减少重复操作

未配置默认路径时：使用上次输出的路径

配置了默认路径时，若勾选了下次使用该路径（本次对话有效），则在关闭前一直默认这个路径

另：version 2.0.0 -> 2.0.1